### PR TITLE
Add test cases for displayName suffix in dev and production

### DIFF
--- a/src/test/css.test.js
+++ b/src/test/css.test.js
@@ -25,4 +25,21 @@ describe('css features', () => {
     shallow(<Comp />)
     expectCSSMatches('.a-styled-div { --custom-prop: some-val; }')
   })
+
+  it('should add custom displayName as className suffix', () => {
+    const Comp = styled.div``
+    Comp.displayName = 'Comp'
+    shallow(<Comp />)
+    expectCSSMatches('.a-Comp { }')
+   })
+
+   it('should not add custom displayName as className suffix in production', () => {
+     const previousNodeEnv = process.env.NODE_ENV
+     process.env.NODE_ENV = 'production'
+     const Comp = styled.div``
+     Comp.displayName = 'Comp'
+     shallow(<Comp />)
+     expectCSSMatches('.a { }')
+     process.env.NODE_ENV = previousNodeEnv
+    })
 })


### PR DESCRIPTION
@JamieDixon Here you go:

- Test that custom `displayName` is appended as `className` suffix when `process.env.NODE_ENV !== 'production'`
- Test that there is no suffix in production

Let me know if there’s anything else, but I think this should be it.